### PR TITLE
Allow ddoc_cache to open restricted design docs

### DIFF
--- a/src/ddoc_cache_opener.erl
+++ b/src/ddoc_cache_opener.erl
@@ -117,10 +117,10 @@ match_newest(Key) ->
     end.
 
 recover_doc(DbName, DDocId) ->
-    fabric:open_doc(DbName, DDocId, [ejson_body]).
+    fabric:open_doc(DbName, DDocId, [ejson_body, ?ADMIN_CTX]).
 
 recover_doc(DbName, DDocId, Rev) ->
-    {ok, [Resp]} = fabric:open_revs(DbName, DDocId, [Rev], [ejson_body]),
+    {ok, [Resp]} = fabric:open_revs(DbName, DDocId, [Rev], [ejson_body, ?ADMIN_CTX]),
     Resp.
 
 recover_validation_funs(DbName) ->


### PR DESCRIPTION
Design docs in the authentication DB cannot be opened without an
admin context so this commit teaches ddoc_cache to always use
?ADMIN_CTX when opening documents.

COUCHDB-2738
